### PR TITLE
Allow lookup for paymentMethods of a specific type

### DIFF
--- a/src/Concerns/ManagesPaymentMethods.php
+++ b/src/Concerns/ManagesPaymentMethods.php
@@ -57,11 +57,11 @@ trait ManagesPaymentMethods
             return collect();
         }
 
-        $parameters = array_merge(['limit' => 24], $parameters);
+        $parameters = array_merge(['limit' => 24, 'type' => 'card'], $parameters);
 
         // "type" is temporarily required by Stripe...
         $paymentMethods = StripePaymentMethod::all(
-            ['customer' => $this->stripe_id, 'type' => 'card'] + $parameters,
+            ['customer' => $this->stripe_id] + $parameters,
             $this->stripeOptions()
         );
 


### PR DESCRIPTION
This addresses #1024.

This change still keeps `type: card` as default type parameter but does allow to use a custom type passed via `$parameters`. 
